### PR TITLE
Fix extra slash in `Machine.spec.providerID`

### DIFF
--- a/pkg/machine/actuator.go
+++ b/pkg/machine/actuator.go
@@ -359,7 +359,7 @@ func machineAddressesFromCloudscaleServer(s cloudscale.Server) []corev1.NodeAddr
 }
 
 func formatProviderID(uuid string) string {
-	return fmt.Sprintf("cloudscale:///%s", uuid)
+	return fmt.Sprintf("cloudscale://%s", uuid)
 }
 
 func providerStatusFromCloudscaleServer(s cloudscale.Server) csv1beta1.CloudscaleMachineProviderStatus {

--- a/pkg/machine/actuator_test.go
+++ b/pkg/machine/actuator_test.go
@@ -162,7 +162,7 @@ func Test_Actuator_Create_ComplexMachineE2E(t *testing.T) {
 	updatedMachine := &machinev1beta1.Machine{}
 	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(machine), updatedMachine))
 	if assert.NotNil(t, updatedMachine.Spec.ProviderID) {
-		assert.Equal(t, "cloudscale:///created-server-uuid", *updatedMachine.Spec.ProviderID)
+		assert.Equal(t, "cloudscale://created-server-uuid", *updatedMachine.Spec.ProviderID)
 	}
 
 	// Labels are just for show with kubectl get
@@ -595,7 +595,7 @@ func Test_Actuator_Update(t *testing.T) {
 	var updatedMachine machinev1beta1.Machine
 	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(machine), &updatedMachine))
 	if assert.NotNil(t, updatedMachine.Spec.ProviderID) {
-		assert.Equal(t, "cloudscale:///machine-uuid", *updatedMachine.Spec.ProviderID)
+		assert.Equal(t, "cloudscale://machine-uuid", *updatedMachine.Spec.ProviderID)
 	}
 }
 


### PR DESCRIPTION
During the reverse engineering of the GCP and AWS providers I erroneously assumed the provider IDs needs three slashes behind `cloudscale:`. In reality it is `gcp://`+`/instance` for those providers. Cloudscale does not have this extra slash.

All machines should be updated to the correct ID on the first reconcile with the fixed code. Node objects get the correct ID from the cloudscale CCM already.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
